### PR TITLE
chore: add og meta for image width and height

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
     <meta property="og:title" content="For Better or Worse" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="/fbow-og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:url" content="https://fbow.org" />
 
     <title>For Better or Worse</title>


### PR DESCRIPTION
Apparently 1200 x 630 is the standard size.

From https://developers.facebook.com/docs/sharing/webmasters/images/:
> Use images that are at least 1200 x 630 pixels for the best display on high resolution devices.

